### PR TITLE
🔥 Fire duplicate row (22,000 -> 9,000)

### DIFF
--- a/database/csv_merge.py
+++ b/database/csv_merge.py
@@ -1,57 +1,14 @@
-import numpy as np
+from csv import QUOTE_MINIMAL
+
 import pandas as pd
 
+amazon_df = pd.read_csv("train/amazon_categories.csv", encoding="utf-8", sep=",", quoting=QUOTE_MINIMAL)
 
-def process_and_adjust_data():
-    # Initial data processing
-    train_df = pd.read_csv("train/train.csv")
-    categories_df = pd.read_csv("train/amazon_categories.csv")
+train_df = pd.read_csv("train/sales.csv", encoding="utf-8")
 
-    columns_to_drop = ["제품", "대분류", "중분류", "소분류", "브랜드"]
-    train_df = train_df.drop(columns=columns_to_drop)
+date_columns = train_df.columns[6:]
+sales_data = train_df[date_columns].iloc[: len(amazon_df)]
 
-    # Generate initial dummy rows
-    required_rows = 22439 - len(train_df)
-    date_columns = [col for col in train_df.columns if col not in ["ID"]]
+final_df = pd.concat([amazon_df[["ID", "Main", "Sub1", "Sub2", "Sub3"]], sales_data], axis=1)
 
-    if required_rows > 0:
-        dummy_data = {"ID": range(max(train_df["ID"]) + 1, max(train_df["ID"]) + required_rows + 1)}
-        for col in date_columns:
-            mean = train_df[col].mean()
-            std = train_df[col].std()
-            dummy_data[col] = np.random.normal(mean, std, required_rows).astype(int)
-
-        dummy_df = pd.DataFrame(dummy_data)
-        train_df = pd.concat([train_df, dummy_df], ignore_index=True)
-
-    # Merge with categories
-    categories_df.columns = ["Main", "Sub1", "Sub2", "Sub3"]
-    merged_df = pd.concat([categories_df, train_df.drop(columns=["ID"])], axis=1)
-    merged_df.to_csv("processed_data.csv", index=False)
-
-    # Adjust distribution
-    time_cols = [col for col in merged_df.columns if col.startswith("202")]
-    final_df = merged_df.copy()
-
-    orig_stats = merged_df.iloc[:15891][time_cols].agg(["mean", "std"]).transpose()
-
-    for col in time_cols:
-        mean, std = orig_stats.loc[col, ["mean", "std"]]
-        new_values = np.random.normal(mean, std, len(merged_df.iloc[15891:]))
-        new_values = np.abs(new_values).astype(int)
-        zero_mask = np.random.random(len(merged_df.iloc[15891:])) < 0.6
-        new_values[zero_mask] = 0
-        final_df.loc[15891:, col] = new_values
-
-    final_df.to_csv("train.csv", index=False)
-    return final_df
-
-
-# Execute and print statistics
-df = process_and_adjust_data()
-time_cols = [col for col in df.columns if col.startswith("202")]
-
-print("\nOriginal data statistics (first 15891 rows):")
-print(df.iloc[:15891][time_cols].describe())
-print("\nGenerated data statistics (remaining rows):")
-print(df.iloc[15891:][time_cols].describe())
+final_df.to_csv("sales.csv", index=False, encoding="utf-8")

--- a/database/csv_to_db.py
+++ b/database/csv_to_db.py
@@ -7,18 +7,17 @@ import pandas as pd
 def convert_to_sqlite():
     # Read CSV and add ID
     df = pd.read_csv("train.csv")
-    df.insert(0, "ID", range(1, len(df) + 1))
 
     # Split data
     product_info = df[["ID", "Main", "Sub1", "Sub2", "Sub3"]]
     time_series_columns = [col for col in df.columns if col.startswith("202")]
-    time_series_data = df[["ID"] + time_series_columns]
+    time_series_data = df[["ID", *time_series_columns]]
 
     # Convert negative values to positive using absolute value
     time_series_data[time_series_columns] = np.abs(time_series_data[time_series_columns])
 
     # Create SQLite database
-    conn = sqlite3.connect("sales_data.db")
+    conn = sqlite3.connect("train.db")
 
     # Save tables with indexes
     product_info.to_sql("product_info", conn, index=False, if_exists="replace")

--- a/database/mapping.py
+++ b/database/mapping.py
@@ -6,9 +6,13 @@ def rename_category_columns(csv_path: str) -> pd.DataFrame:
     df = df.rename(columns={"Mai Category": "Main", "Subcategory 1": "Sub1", "Subcategory 2": "Sub2", "Subcategory 3": "Sub3"})
     df = df.dropna(subset=["Sub2", "Sub3"])
     df.insert(0, "ID", range(len(df)))
+
+    # Main, Sub1, Sub2, Sub3 컬럼을 기준으로 중복 제거
+    df = df.drop_duplicates(subset=["Main", "Sub1", "Sub2", "Sub3"])
+
     return df[["ID", "Main", "Sub1", "Sub2", "Sub3"]]
 
 
 if __name__ == "__main__":
-    df = rename_category_columns("amazon_categories.csv")
+    df = rename_category_columns("origin/amazon_categories.csv")
     df.to_csv("train/amazon_categories.csv", index=False)


### PR DESCRIPTION
## 🎯 Description
1. The number of row 정리
- dacon : 15,000
- amazon_categories : 22,000
- amazon_categories for only unique value : 9,000

- 중복된 값은 의미 없을 것 같다는 동환님의 의견을 반영해서, 9,000개로 변경했습니다.

## 🔨 Change logs
- 기존의 22,000개의 row로 DB 변환하던 내용을 9,000개의 중복되지 않은 값들로 변경했습니다.

## 👥 To Reviewer

## 🔗 Related Issue
- Closed | Fixed: #
- See also: #
